### PR TITLE
schedules repo done

### DIFF
--- a/backend/internal/domain/query.go
+++ b/backend/internal/domain/query.go
@@ -28,7 +28,7 @@ type ShiftsFiltersQuery struct {
 	Status   string `form:"status"`
 }
 
-type GetOrdersQuery struct {
+type GetSchedulesQuery struct {
 	PaginationQuery
 	SearchQuery
 	ShiftsFiltersQuery

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -61,21 +61,19 @@ type Shifts interface {
 	Update(ctx context.Context, shiftID primitive.ObjectID, input UpdateShiftInput) error
 	Delete(ctx context.Context, shiftID primitive.ObjectID) error
 	GetById(ctx context.Context, shiftID primitive.ObjectID) (domain.Shift, error)
-	GetByStatus(ctx context.Context, shiftID primitive.ObjectID, status string) (domain.Shifts, error)
+	GetByStatus(ctx context.Context, shiftID primitive.ObjectID, status string, query domain.GetShiftsQuery) (domain.Shifts, int64, error)
 	SetStatus(ctx context.Context, shiftID primitive.ObjectID, status string) error
 }
 
 type UpdateScheduleInput struct {
-	WorkstationID primitive.ObjectID
-	EmployeeID    primitive.ObjectID
-	ShiftID       primitive.ObjectID
+	EmployeeID primitive.ObjectID
 }
 
 type Schedules interface {
 	Create(ctx context.Context, schedule domain.Schedule) (primitive.ObjectID, error)
-	Update(ctx context.Context, scheduleID primitive.ObjectID, input UpdateScheduleInput) error
-	Delete(ctx context.Context, employeeID primitive.ObjectID, scheduleID primitive.ObjectID) error
-	GetByEmployee(ctx context.Context, employeeID primitive.ObjectID) (domain.Schedules, error)
+	Update(ctx context.Context, scheduleID primitive.ObjectID, employeeID primitive.ObjectID) error
+	Delete(ctx context.Context, scheduleID primitive.ObjectID) error
+	GetByEmployee(ctx context.Context, employeeID primitive.ObjectID, query domain.GetSchedulesQuery) (domain.Schedules, int64, error)
 	GetById(ctx context.Context, scheduleID primitive.ObjectID) (domain.Schedule, error)
 	GetByShift(ctx context.Context, shiftID primitive.ObjectID) (domain.Schedule, error)
 	GetByIds(ctx context.Context, scheduleIDs []primitive.ObjectID) (domain.Schedules, error)
@@ -94,8 +92,8 @@ func NewRepositories(db *mongo.Database) *Repositories {
 		Managers:     NewManagersRepo(db),
 		Workstations: NewWorkstationsRepo(db),
 		Employees:    NewEmployeesRepo(db),
-		// Shifts:       NewShiftsRepo(db),
-		// Schedules:    NewSchedulesRepo(db),
+		Shifts:       NewShiftsRepo(db),
+		Schedules:    NewSchedulesRepo(db),
 	}
 }
 

--- a/backend/internal/repository/schedules_mongo.go
+++ b/backend/internal/repository/schedules_mongo.go
@@ -1,0 +1,104 @@
+package repository
+
+import (
+	"context"
+	"employee-management-webapp/internal/domain"
+	"errors"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type SchedulesRepo struct {
+	db *mongo.Collection
+}
+
+func NewSchedulesRepo(db *mongo.Database) *SchedulesRepo {
+	return &SchedulesRepo{
+		db: db.Collection(schedulesCollection),
+	}
+}
+
+func (r *SchedulesRepo) Create(ctx context.Context, schedule domain.Schedule) (primitive.ObjectID, error) {
+	res, err := r.db.InsertOne(ctx, schedule)
+	schedule.ID = res.InsertedID.(primitive.ObjectID)
+
+	return res.InsertedID.(primitive.ObjectID), err
+}
+
+func (r *SchedulesRepo) Update(ctx context.Context, scheduleID primitive.ObjectID, employeeID primitive.ObjectID) error {
+	var err error
+	if scheduleID != primitive.NilObjectID && employeeID != primitive.NilObjectID {
+		_, err = r.db.UpdateOne(ctx, bson.M{"_id": scheduleID}, bson.M{"$set": bson.M{"employeeId": employeeID}})
+	}
+
+	return err
+}
+
+func (r *SchedulesRepo) Delete(ctx context.Context, scheduleID primitive.ObjectID) error {
+	_, err := r.db.DeleteOne(ctx, bson.M{"_id": scheduleID})
+
+	return err
+}
+
+func (r *SchedulesRepo) GetByEmployee(ctx context.Context, employeeID primitive.ObjectID, query domain.GetSchedulesQuery) (domain.Schedules, int64, error) {
+	paginationOpts := getPaginationOpts(&query.PaginationQuery)
+	paginationOpts.SetSort(bson.M{"date": -1})
+	var schedules domain.Schedules
+
+	cur, err := r.db.Find(ctx, bson.M{"employeeId": employeeID}, paginationOpts)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	err = cur.All(ctx, &schedules)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	count, err := r.db.CountDocuments(ctx, bson.M{"employeeId": employeeID})
+
+	return schedules, count, err
+}
+
+func (r *SchedulesRepo) GetById(ctx context.Context, scheduleID primitive.ObjectID) (domain.Schedule, error) {
+	var schedule domain.Schedule
+
+	if err := r.db.FindOne(ctx, bson.M{"_id": scheduleID}).Decode(&schedule); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return domain.Schedule{}, domain.ErrScheduleNotFound
+		}
+
+		return domain.Schedule{}, err
+	}
+
+	return schedule, nil
+}
+
+func (r *SchedulesRepo) GetByShift(ctx context.Context, shiftID primitive.ObjectID) (domain.Schedule, error) {
+	var schedule domain.Schedule
+
+	if err := r.db.FindOne(ctx, bson.M{"shiftId": shiftID}).Decode(&schedule); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return domain.Schedule{}, domain.ErrScheduleNotFound
+		}
+
+		return domain.Schedule{}, err
+	}
+
+	return schedule, nil
+}
+
+func (r *SchedulesRepo) GetByIds(ctx context.Context, scheduleIDs []primitive.ObjectID) (domain.Schedules, error) {
+	var schedules domain.Schedules
+
+	cur, err := r.db.Find(ctx, bson.M{"_id": bson.M{"$in": scheduleIDs}})
+	if err != nil {
+		return nil, err
+	}
+
+	err = cur.All(ctx, &schedules)
+
+	return schedules, err
+}


### PR DESCRIPTION
@ThePaulin Done! At the time of schedule creation, a shift must be created and attached to the schedule, as well as employee and workstation. When we are talking about updating a schedule, one of the use cases is when u want to assign a different employee to the schedule. I am still open to add another field(s) we might think is necessary when updating a schedule but for now I thought this was the most important use case.